### PR TITLE
恢复许可证并使Android支持Unifont显示

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,3 @@
----
-permalink: /LICENSE/
----
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<link rel="icon" href="https://creativecommons.org/wp-content/uploads/2016/05/cc-site-icon-40x40.png" sizes="32x32" />
-<title>Attribution-ShareAlike 4.0 International</title>
-</head>
-<body>
-<pre style="width:800px;margin:auto;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;">
 Attribution-ShareAlike 4.0 International
 
 =======================================================================
@@ -437,6 +425,3 @@ the avoidance of doubt, this paragraph does not form part of the public
 licenses.
 
 Creative Commons may be contacted at creativecommons.org.
-</pre>
-</body>
-</html>

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -13,5 +13,5 @@
 
 @font-face {
 	font-family: Unifont;
-	src: url("http://unifoundry.com/pub/unifont/unifont-15.0.06/font-builds/unifont-15.0.06.otf");
+	src: url("http://unifoundry.com/pub/unifont/unifont-15.0.06/font-builds/unifont-15.0.06.ttf");
 }


### PR DESCRIPTION
[=] 通过更换路径修复Android无法加载OTF格式字体问题
[=] 恢复了许可证在GitHub的显示问题